### PR TITLE
Add examples for Page and PagePermissions

### DIFF
--- a/examples/port-python/__main__.py
+++ b/examples/port-python/__main__.py
@@ -1,8 +1,52 @@
 """A Python Pulumi program"""
-
+import json
 import pulumi
-from port_pulumi import Entity,EntityPropertiesArgs
+from port_pulumi import Entity, EntityPropertiesArgs, Page, PagePermissions
 
-entity = Entity("port_pulumi", title="monolith", blueprint="microservice",
-                properties=EntityPropertiesArgs(string_props={"language": "python"}),
-                )
+# Creating an entity
+entity = Entity(
+    "port_pulumi",
+    title="monolith",
+    blueprint="microservice",
+    properties=EntityPropertiesArgs(string_props={"language": "python"}),
+)
+
+# Creating a page
+catalog_page = Page(
+    "my-catalog-page-resource",
+    identifier="my_catalog_page",
+    title="Our Services",
+    blueprint="service",
+    icon="Microservice",
+    type="blueprint-entities",
+    widgets=[
+        json.dumps(
+            {
+                "displayMode": "widget",
+                "title": "Services",
+                "type": "table-entities-explorer",
+                "dataset": {
+                    "combinator": "and",
+                    "rules": [
+                        {"operator": "=", "value": "service", "property": "$blueprint"}
+                    ],
+                },
+                "id": "servicesTable-en",
+                "excludedFields": ["properties.readme", "properties.slack"],
+            }
+        )
+    ],
+)
+
+# Page Permissions: Allow read access to all admins and a specific user and team
+microservices_permissions = PagePermissions(
+    "catalog_page_permissions",
+    page_identifier="my_catalog_page",
+    read={
+        "roles": [
+            "Admin",
+        ],
+        "users": ["one_of_your_users@gmail.com"],
+        "teams": ["Your Team"],
+    },
+)


### PR DESCRIPTION
More practical examples of the provider

# Description

_**What**_ - This pull request focuses on providing more practical examples for the Pulumi Port Provider.

**_Why_** - Additional examples enhance the usability of the provider, allowing users to better understand its capabilities and how to leverage them in various scenarios.

**_How_** - Introduced new examples in the codebase to showcase diverse use cases and scenarios where the Pulumi Port Provider can be effectively utilized.

## Type of change

- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)