### PR TITLE
updated the go version in the "release" github-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-          - '1.20'
+          - '1.22'
   publish_sdk:
     name: Publish SDKs
     runs-on: ubuntu-latest
@@ -126,4 +126,4 @@ jobs:
         pythonversion:
           - "3.9"
         goversion:
-          - '1.20'
+          - '1.22'


### PR DESCRIPTION
# Description

What - updated the release action's golang version
Why - some toolchain stuff only exist starting version 1.21

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)