### PR TITLE
Update upgrade-provider-only.yaml go-version to 1.24

### DIFF
--- a/.github/workflows/upgrade-provider-only.yaml
+++ b/.github/workflows/upgrade-provider-only.yaml
@@ -11,6 +11,7 @@ jobs:
         kind: provider
         email: getport.io
         username: pulumi-port-bot
+        go-version: '1.24'
 name: Upgrade the TF provider only
 
 permissions:


### PR DESCRIPTION
# Description

What - Update upgrade-provider-only.yaml go-version to 1.24
Why - to support `terraform-provider-port-labs` 2.7.0
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)