### PR TITLE
Add new required make command generate_sdks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ tfgen:: install_plugins
 provider:: tfgen install_plugins # build the provider binary
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})
 
-build_sdks:: install_plugins provider build_nodejs build_python build_go #build_dotnet build_java # build all the sdks
+generate_sdks:: install_plugins provider build_nodejs build_python build_go #build_dotnet build_java # build all the sdks
+build_sdks:: generate_sdks
+
 
 # build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs:: install_plugins tfgen # build the node sdk


### PR DESCRIPTION
# Description

What - Add new required make command generate_sdks
Why - In https://github.com/pulumi/upgrade-provider/pull/312 they changed the command to run from build_sdks to generate_sdks
How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)